### PR TITLE
fix: ci checks out wrong code

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,7 +1,7 @@
 name: Lint Checks (ESLint / Prettier)
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Tests
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
 


### PR DESCRIPTION
see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.