### PR TITLE
fix: await handlers so any errors are caught

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -17,11 +17,11 @@ const cloudflareWorker: Worker = {
       switch (request.method) {
         case 'HEAD':
         case 'GET':
-          return handlers.get(request, env, ctx, cache);
+          return await handlers.get(request, env, ctx, cache);
         case 'POST':
-          return handlers.post(request, env, ctx, cache);
+          return await handlers.post(request, env, ctx, cache);
         case 'OPTIONS':
-          return handlers.options(request, env, ctx, cache);
+          return await handlers.options(request, env, ctx, cache);
         default:
           return responses.METHOD_NOT_ALLOWED;
       }


### PR DESCRIPTION
We weren't awaiting the handlers causing any errors that happen past a point to be caught by Workerd rather than our try/catch block in the entrypoint