### PR TITLE
src: report errors to sentry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-sdk/client-s3": "^3.423.0",
         "handlebars": "^4.7.8",
         "nodejs-latest-linker": "^1.6.0",
+        "toucan-js": "^3.3.1",
         "zod": "^3.22.2"
       },
       "devDependencies": {
@@ -1525,6 +1526,51 @@
       "dependencies": {
         "@actions/core": "^1.10.0",
         "stack-utils": "^2.0.6"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.76.0.tgz",
+      "integrity": "sha512-M+ptkCTeCNf6fn7p2MmEb1Wd9/JXUWxIT/0QEc+t11DNR4FYy1ZP2O9Zb3Zp2XacO7ORrlL3Yc+VIfl5JTgjfw==",
+      "dependencies": {
+        "@sentry/types": "7.76.0",
+        "@sentry/utils": "7.76.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.76.0.tgz",
+      "integrity": "sha512-4ea0PNZrGN9wKuE/8bBCRrxxw4Cq5T710y8rhdKHAlSUpbLqr/atRF53h8qH3Fi+ec0m38PB+MivKem9zUwlwA==",
+      "dependencies": {
+        "@sentry/core": "7.76.0",
+        "@sentry/types": "7.76.0",
+        "@sentry/utils": "7.76.0",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.76.0.tgz",
+      "integrity": "sha512-vj6z+EAbVrKAXmJPxSv/clpwS9QjPqzkraMFk2hIdE/kii8s8kwnkBwTSpIrNc8GnzV3qYC4r3qD+BXDxAGPaw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.76.0.tgz",
+      "integrity": "sha512-40jFD+yfQaKpFYINghdhovzec4IEpB7aAuyH/GtE7E0gLpcqnC72r55krEIVILfqIR2Mlr5OKUzyeoCyWAU/yw==",
+      "dependencies": {
+        "@sentry/types": "7.76.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@smithy/abort-controller": {
@@ -3430,6 +3476,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -3677,6 +3728,22 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -4743,6 +4810,17 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toucan-js": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/toucan-js/-/toucan-js-3.3.1.tgz",
+      "integrity": "sha512-9BpkHb/Pzsrtl1ItNq9OEQPnuUHwzce0nV2uG+DYFiQ4fPyiA6mKTBcDwQzcvNkfSER038U+8TzvdkCev+Maww==",
+      "dependencies": {
+        "@sentry/core": "7.76.0",
+        "@sentry/integrations": "7.76.0",
+        "@sentry/types": "7.76.0",
+        "@sentry/utils": "7.76.0"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@aws-sdk/client-s3": "^3.423.0",
     "handlebars": "^4.7.8",
     "nodejs-latest-linker": "^1.6.0",
+    "toucan-js": "^3.3.1",
     "zod": "^3.22.2"
   }
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -44,4 +44,9 @@ export interface Env {
    * Cache control header for directory listing
    */
   DIRECTORY_CACHE_CONTROL: string;
+  /**
+   * Sentry DSN, used for error monitoring
+   * If missing, Sentry isn't used
+   */
+  SENTRY_DSN?: string;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,6 +1,7 @@
 import { Env } from './env';
 import responses from './commonResponses';
 import handlers from './handlers';
+import { Toucan } from 'toucan-js';
 
 interface Worker {
   /**
@@ -13,6 +14,17 @@ interface Worker {
 const cloudflareWorker: Worker = {
   fetch: async (request, env, ctx) => {
     const cache = caches.default;
+
+    const sentry = new Toucan({
+      dsn: env.SENTRY_DSN,
+      request,
+      context: ctx,
+      requestDataOptions: {
+        allowedHeaders: true,
+        allowedIps: true,
+      },
+    });
+
     try {
       switch (request.method) {
         case 'HEAD':
@@ -26,6 +38,9 @@ const cloudflareWorker: Worker = {
           return responses.METHOD_NOT_ALLOWED;
       }
     } catch (e) {
+      // Send to sentry, if it's disabled this will just noop
+      sentry.captureException(e);
+
       let responseBody = 'Internal Server Error';
 
       if (env.ENVIRONMENT === 'dev' && e instanceof Error) {


### PR DESCRIPTION
Note: need to add the dsn under the SENTRY_DSN secret.

Was going to use Sentry's official client `@sentry/node` , but I'm not sure if it's compatible with Workers. `toucan-js` is specifically meant as a Sentry client for Workers, and it's even being used in some of Cloudflare's own modules https://github.com/cloudflare/worker-sentry/blob/74ffc72bbd305fcbf832f873342967ae9de7088f/package.json#L17