### PR TITLE
actions: auto deploy redirect updates to production

### DIFF
--- a/.github/workflows/update-links.yml
+++ b/.github/workflows/update-links.yml
@@ -49,4 +49,11 @@ jobs:
           gh pr merge --squash --delete-branch --admin
         env:
           GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+
+      - name: Deploy to Production
+        if: steps.git_auto_commit.outputs.changes_detected == 'true'
+        run: |
+          gh workflow run deploy.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         


### PR DESCRIPTION
As of now updates to `src/constants/redirectLinks.json` are being automatically merged into `main`, however they're only being automatically deployed to staging. We still need to manually deploy the change to production in order for it to take effect

For reference the last time the worker updated the redirects here https://github.com/nodejs/release-cloudflare-worker/actions/runs/7040199325/job/19160694531 and when I deployed to prod here https://github.com/nodejs/release-cloudflare-worker/actions/runs/7042036821/job/19165548546

There is also a way we can do this without needing to run the action twice. Here https://github.com/nodejs/release-cloudflare-worker/blob/0949b3694275c7c6a09d15926d466bc941fd61d3/.github/workflows/deploy.yml#L26 we could check if the commit is from the @nodejs-github-bot user and/or if the commit is titled `chore: update redirect links`