### PR TITLE
Remove /metrics redirects

### DIFF
--- a/src/constants/r2Prefixes.ts
+++ b/src/constants/r2Prefixes.ts
@@ -34,5 +34,4 @@ export const URL_TO_BUCKET_PATH_MAP: Record<string, (path: string) => string> =
       DOCS_PATH_PREFIX + (path.substring('/docs'.length) || '/'),
     api: (path): string =>
       API_PATH_PREFIX + (path.substring('/api'.length) || '/'),
-    metrics: (path): string => path.substring(1), // substring to cut off the /
   };

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -147,9 +147,6 @@ export function mapBucketPathToUrlPath(
   } else if (bucketPath.startsWith(DOWNLOAD_PATH_PREFIX)) {
     // Rest of the `/download/...` paths (e.g. `/download/nightly/`)
     return [`/download${bucketPath.substring(DOWNLOAD_PATH_PREFIX.length)}`];
-  } else if (bucketPath.startsWith('metrics')) {
-    // Metrics doesn't need any redirects
-    return ['/' + bucketPath];
   }
 
   return env.DIRECTORY_LISTING === 'restricted'

--- a/tests/e2e/directory.test.ts
+++ b/tests/e2e/directory.test.ts
@@ -24,9 +24,8 @@ async function startS3Mock(): Promise<http.Server> {
     const r2Prefix = url.searchParams.get('prefix')!;
 
     let doesFolderExist =
-      ['nodejs/release/', 'nodejs/', 'nodejs/docs/'].includes(
-        r2Prefix
-      ) || r2Prefix.endsWith('/docs/api/');
+      ['nodejs/release/', 'nodejs/', 'nodejs/docs/'].includes(r2Prefix) ||
+      r2Prefix.endsWith('/docs/api/');
 
     if (doesFolderExist) {
       xmlFilePath += 'ListObjectsV2-exists.xml';

--- a/tests/e2e/directory.test.ts
+++ b/tests/e2e/directory.test.ts
@@ -24,7 +24,7 @@ async function startS3Mock(): Promise<http.Server> {
     const r2Prefix = url.searchParams.get('prefix')!;
 
     let doesFolderExist =
-      ['nodejs/release/', 'nodejs/', 'nodejs/docs/', 'metrics/'].includes(
+      ['nodejs/release/', 'nodejs/', 'nodejs/docs/'].includes(
         r2Prefix
       ) || r2Prefix.endsWith('/docs/api/');
 
@@ -140,20 +140,6 @@ describe('Directory Tests (Restricted Directory Listing)', () => {
 
   it('allows `/api/`', async () => {
     const res = await mf.dispatchFetch(`${url}api/`);
-    assert.strictEqual(res.status, 200);
-  });
-
-  it('redirects `/metrics` to `/metrics/`', async () => {
-    const originalRes = await mf.dispatchFetch(`${url}metrics`, {
-      redirect: 'manual',
-    });
-    assert.strictEqual(originalRes.status, 301);
-    const res = await mf.dispatchFetch(originalRes.headers.get('location')!);
-    assert.strictEqual(res.status, 200);
-  });
-
-  it('allows `/metrics/`', async () => {
-    const res = await mf.dispatchFetch(`${url}metrics/`);
     assert.strictEqual(res.status, 200);
   });
 


### PR DESCRIPTION
Ref: <https://github.com/nodejs/build/pull/3744>

This PR removes the special routing rules for the `/metrics` route. Eventually the routes may be added to the nodejs.org repository. See <https://github.com/nodejs/build/pull/3744> or <https://openjs-foundation.slack.com/archives/CVAMEJ4UV/p1716930902490479?thread_ts=1716925791.042909&cid=CVAMEJ4UV> for more information. 

(CC) @flakey5 
(CC) @targos 