### PR TITLE
src: don't cache origin requests

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -9,7 +9,7 @@ import type { Router } from './router';
 
 export function registerRoutes(router: Router): void {
   const r2Middleware = cached(new R2Middleware());
-  const originMiddleware = cached(new OriginMiddleware());
+  const originMiddleware = new OriginMiddleware();
 
   router.options('*', [new OptionsMiddleware()]);
 


### PR DESCRIPTION
Quick fix, responses from fetch() are immutable and so the cache middleware throws when adding headers. Will get a better fix soon^tm