### PR TITLE
src: don't add cache headers

### DIFF
--- a/src/middleware/cacheMiddleware.ts
+++ b/src/middleware/cacheMiddleware.ts
@@ -50,12 +50,9 @@ export function cached(middleware: Middleware): Middleware {
       if (!wasDeferred && response.status === 200) {
         // Successful request, let's cache it for next time
         const cachedResponse = response.clone();
-        cachedResponse.headers.append('x-cache-status', 'hit');
 
         ctx.execution.waitUntil(cache.put(request, cachedResponse));
       }
-
-      response.headers.append('x-cache-status', 'miss');
 
       return response;
     },


### PR DESCRIPTION
Investigating why staging always falls back to the origin for directory listings after #125, this will _hopefully_ fix things

Sentry ref: https://nodejs-org.sentry.io/issues/5799625624/