### PR TITLE
src: handle object name errors more gracefully

### DIFF
--- a/src/middleware/r2Middleware.ts
+++ b/src/middleware/r2Middleware.ts
@@ -116,9 +116,14 @@ async function getFile(
       conditionalHeaders: parseConditionalHeaders(request.headers),
     });
   } catch (err) {
-    // Check if R2 threw a range not compatible error
-    if (err instanceof Error && err.message.includes('10039')) {
-      return new Response(undefined, { status: 416 });
+    if (err instanceof Error) {
+      if (err.message.includes('10020')) {
+        // Object name not valid, url probably has some weirdness in it
+        return new Response(undefined, { status: 400 });
+      } else if (err.message.includes('10039')) {
+        // Range not compatible, probably out of bounds
+        return new Response(undefined, { status: 416 });
+      }
     }
 
     ctx.sentry.captureException(err);


### PR DESCRIPTION
These appear to be from clients sending chunks of the directory listing html as the path in the url (e.g. `https://nodejs.org/dist/v21.2.0-aix-ppc64.tar.gz'%3Enode-v21.2.0-aix-ppc64.tar.gz%3C/a%3E%3C/` -> `https://nodejs.org/dist/v21.2.0-aix-ppc64.tar.gz'>node-v21.2.0-aix-ppc64.tar.gz</a></`)

Closes #165