### PR TITLE
fix: serve index.tab files as text files

### DIFF
--- a/src/constants/contentTypeOverrides.json
+++ b/src/constants/contentTypeOverrides.json
@@ -1,0 +1,3 @@
+{
+  "tab": "text/plain"
+}

--- a/src/providers/r2Provider.ts
+++ b/src/providers/r2Provider.ts
@@ -101,14 +101,10 @@ function r2MetadataToHeaders(
 
   const fileExtension = object.key.substring(object.key.lastIndexOf('.') + 1);
 
-  let contentType: string;
-  if (fileExtension in contentTypeOverrides) {
-    contentType =
-      contentTypeOverrides[fileExtension as keyof typeof contentTypeOverrides];
-  } else {
-    contentType =
-      object.httpMetadata?.contentType ?? 'application/octet-stream';
-  }
+  const contentType =
+    contentTypeOverrides[fileExtension as keyof typeof contentTypeOverrides] ??
+    object.httpMetadata?.contentType ??
+    'application/octet-stream';
 
   return {
     etag: object.httpEtag,

--- a/src/providers/r2Provider.ts
+++ b/src/providers/r2Provider.ts
@@ -1,5 +1,6 @@
 import { CACHE_HEADERS } from '../constants/cache';
 import { R2_RETRY_LIMIT } from '../constants/limits';
+import contentTypeOverrides from '../constants/contentTypeOverrides.json' assert { type: 'json' };
 import type { Context } from '../context';
 import { objectHasBody } from '../utils/object';
 import { retryWrapper } from '../utils/provider';
@@ -98,14 +99,15 @@ function r2MetadataToHeaders(
 ): HttpResponseHeaders {
   const { httpMetadata } = object;
 
+  const fileExtension = object.key.substring(object.key.lastIndexOf('.') + 1);
+
   let contentType: string;
-  if (object.httpMetadata?.contentType !== undefined) {
-    contentType = object.httpMetadata.contentType;
+  if (fileExtension in contentTypeOverrides) {
+    contentType =
+      contentTypeOverrides[fileExtension as keyof typeof contentTypeOverrides];
   } else {
-    // Serve .tab files as text files
-    contentType = object.key.endsWith('.tab')
-      ? 'text/plain'
-      : 'application/octet-stream';
+    contentType =
+      object.httpMetadata?.contentType ?? 'application/octet-stream';
   }
 
   return {

--- a/src/providers/r2Provider.ts
+++ b/src/providers/r2Provider.ts
@@ -98,10 +98,19 @@ function r2MetadataToHeaders(
 ): HttpResponseHeaders {
   const { httpMetadata } = object;
 
+  let contentType: string;
+  if (object.httpMetadata?.contentType !== undefined) {
+    contentType = object.httpMetadata.contentType;
+  } else {
+    // Serve .tab files as text files
+    contentType = object.key.endsWith('.tab')
+      ? 'text/plain'
+      : 'application/octet-stream';
+  }
+
   return {
     etag: object.httpEtag,
-    'content-type':
-      object.httpMetadata?.contentType ?? 'application/octet-stream',
+    'content-type': contentType,
     'accept-range': 'bytes',
     // https://github.com/nodejs/build/blob/e3df25d6a23f033db317a53ab1e904c953ba1f00/ansible/www-standalone/resources/config/nodejs.org?plain=1#L194-L196
     'access-control-allow-origin': object.key.endsWith('.json') ? '*' : '',


### PR DESCRIPTION
nginx serves .tab files as `text/plain` but the worker serves them as `application/octet-stream` https://direct.nodejs.org/dist/index.tab