### PR TITLE
actions: add timeout to jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   deploy:
     name: Deploy Cloudflare Worker
+    timeout-minutes: 5
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   lint:
     name: Check Linting and Formatting
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     if: ${{ github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'synchronize' || (github.event.action == 'labeled' && github.event.label.name == 'force ci') }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'synchronize' || (github.event.action == 'labeled' && github.event.label.name == 'force ci') }}
 
     steps:
@@ -34,6 +35,7 @@ jobs:
   e2e-test:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'synchronize' || (github.event.action == 'labeled' && github.event.label.name == 'force ci') }}
 
     steps:


### PR DESCRIPTION
Adds a timeout in case jobs don't quit by themselves for whatever reason

Re https://github.com/nodejs/release-cloudflare-worker/actions/runs/12996566677/job/36245623529?pr=234 which was running for 3 hours