### PR TITLE
fix: don't return 412 for if-none-match failures

### DIFF
--- a/src/providers/r2Provider.ts
+++ b/src/providers/r2Provider.ts
@@ -180,13 +180,10 @@ function areConditionalHeadersPresent(
 
   const { conditionalHeaders } = options;
 
-  // Only check for if-none-match and if-unmodified-since because the docs said
+  // Only check for if-unmodified-since because the docs said
   //  so, also what nginx does from my experiments
   //  https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
-  return (
-    conditionalHeaders.ifNoneMatch !== undefined ||
-    conditionalHeaders.ifUnmodifiedSince !== undefined
-  );
+  return conditionalHeaders.ifUnmodifiedSince !== undefined;
 }
 
 function determineHttpStatusCode(
@@ -208,7 +205,7 @@ function determineHttpStatusCode(
     return 412;
   }
 
-  // We weren't given a body and preconditions succeeded.
+  // We weren't given a body
   return 304;
 }
 

--- a/tests/e2e/file.test.ts
+++ b/tests/e2e/file.test.ts
@@ -160,7 +160,7 @@ describe('File Tests', () => {
         'if-none-match': originalETag,
       },
     });
-    assert(res.status === 304 || res.status === 412);
+    assert(res.status === 304);
   });
 
   it('handles range header correctly', async () => {


### PR DESCRIPTION
Closes nodejs/build#4030

Misinterpretation of the docs, precondition failures due to `if-none-match` return a 412 for unsafe http methods (aka those that modify things on the sever-side). For safe methods (GET, HEAD), they return a 304.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match