### PR TITLE
actions: restrict concurrency on update-links workflow

### DIFF
--- a/.github/workflows/update-links.yml
+++ b/.github/workflows/update-links.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  group: update-redirect-links
+  cancel-in-progress: false
+
 jobs:
   update-redirect-links:
     name: Update Redirect Links


### PR DESCRIPTION
Should stop the workflow racing itself as seen in #439 + #440