### PR TITLE
actions: run dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       prefix: chore
     open-pull-requests-limit: 10
@@ -11,7 +11,7 @@ updates:
     directory: '/'
     versioning-strategy: increase
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       prefix: chore
     groups:


### PR DESCRIPTION
Run dependabot monthly instead of weekly.

We don't really need to be running dependabot this frequently. Monthly is also already what we're using for the website and doc-kit.