### PR TITLE
ci: set 3-day cooldown for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: monthly
     commit-message:
       prefix: chore
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
   - package-ecosystem: npm
     directory: '/'
@@ -14,6 +16,8 @@ updates:
       interval: monthly
     commit-message:
       prefix: chore
+    cooldown:
+      default-days: 3
     groups:
       format:
         patterns:


### PR DESCRIPTION
https://github.com/nodejs/web-team/issues/25