### PR TITLE
dependabot: update groupings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,11 @@ updates:
         patterns:
           - 'eslint'
           - 'eslint-*'
+          - '@eslint/*'
           - '@typescript-eslint/*'
+      vitest:
+        patterns:
+          - 'vitest'
+          - '@cloudflare/vitest-pool-workers'
     ignore:
       - dependency-name: nodejs-latest-linker


### PR DESCRIPTION
- add `@eslint/*` packages to lint group
- create vitest group for vitest related packages