### PR TITLE
src: enable kv directory listing for some dirs

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -22,6 +22,11 @@ export interface Env {
   USE_KV: boolean;
 
   /**
+   * Temp list of directory prefixes that KV should be used for listing
+   */
+  KV_DIRECTORIES?: Array<string>;
+
+  /**
    * Endpoint to hit when using the S3 api.
    */
   S3_ENDPOINT: string;

--- a/src/providers/r2Provider.ts
+++ b/src/providers/r2Provider.ts
@@ -107,7 +107,15 @@ export class R2Provider implements Provider {
     });
 
     if (this.ctx.env.USE_KV) {
-      return await kvProvider.readDirectory(path);
+      if (this.ctx.env.KV_DIRECTORIES !== undefined) {
+        for (const prefix of this.ctx.env.KV_DIRECTORIES) {
+          if (path.startsWith(prefix)) {
+            return await kvProvider.readDirectory(path);
+          }
+        }
+      } else {
+        return await kvProvider.readDirectory(path);
+      }
     }
 
     let result: ReadDirectoryResult | undefined;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -87,6 +87,17 @@
         "S3_ENDPOINT": "https://07be8d2fbc940503ca1be344714cb0d1.r2.cloudflarestorage.com",
         "BUCKET_NAME": "dist-prod",
         "ORIGIN_HOST": "https://origin.nodejs.org",
+        "KV_DIRECTORIES": [
+          "metrics/",
+          "nodejs/chakracore-nightly/",
+          "nodejs/chakracore-rc/",
+          "nodejs/chakracore-release/",
+          "nodejs/docs/",
+          "nodejs/nightly/",
+          "nodejs/rc/",
+          "nodejs/test/",
+          "nodejs/v8-canary/"
+        ]
       },
       "r2_buckets": [
         {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -87,6 +87,7 @@
         "S3_ENDPOINT": "https://07be8d2fbc940503ca1be344714cb0d1.r2.cloudflarestorage.com",
         "BUCKET_NAME": "dist-prod",
         "ORIGIN_HOST": "https://origin.nodejs.org",
+        "USE_KV": true,
         "KV_DIRECTORIES": [
           "metrics/",
           "nodejs/chakracore-nightly/",


### PR DESCRIPTION
Enables kv-backed directory listing for every path other than mainline releases (`nodejs/release/`) in prod. Staging remains serving kv-backed listings for all paths.