### PR TITLE
ci: fix unsupported ?? operator in workflow expression

### DIFF
--- a/.github/workflows/update-links.yml
+++ b/.github/workflows/update-links.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Update Directory Cache
         run: node scripts/update-directory-cache.mjs "$VERSION_INPUT" && node --run format
         env:
-          VERSION_INPUT: '${{ inputs.version ?? "" }}'
+          VERSION_INPUT: "${{ inputs.version || '' }}"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           S3_ACCESS_KEY_ID: ${{ secrets.CF_ACCESS_KEY_ID }}
           S3_ACCESS_KEY_SECRET: ${{ secrets.CF_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
GitHub Actions expression syntax doesn't support `??` (nullish coalescing). Replace with `||` to restore the update-links workflow.

Fixes #1020