### PR TITLE
meta: exclude .github/ from Prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 src/templates/*.out.json
+.github/


### PR DESCRIPTION
Prettier reformats workflow YAML on every `format` run — e.g. normalising `cron: "0 0 * * *"` to single quotes. The update-links workflow runs `node --run format` before committing, so `git-auto-commit-action` picks up the diff and tries to push a workflow file change. GitHub rejects that unless the token has `workflows` write permission.

Adding `.github/` to `.prettierignore` stops the nightly run from producing spurious workflow file diffs.

Refs #1020