### PR TITLE
chore: apply Prettier formatting to all files

### DIFF
--- a/.github/workflows/update-links.yml
+++ b/.github/workflows/update-links.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
   schedule:
-    - cron: "0 0 * * *"
+    - cron: '0 0 * * *'
 
 concurrency:
   group: update-redirect-links

--- a/scripts/constants.mjs
+++ b/scripts/constants.mjs
@@ -58,4 +58,8 @@ export const STATIC_FILE_SYMLINKS_PATH = join(
  * Paths in the R2 bucket that we should always be updating whenever a new
  * version releases.
  */
-export const ALWAYS_UPDATED_PATHS = [RELEASE_DIR, DOCS_DIR, NIGHTLY_RELEASES_DIR];
+export const ALWAYS_UPDATED_PATHS = [
+  RELEASE_DIR,
+  DOCS_DIR,
+  NIGHTLY_RELEASES_DIR,
+];


### PR DESCRIPTION
The nightly update-links workflow runs `node --run format` before committing the directory cache, and the Prettier format script covers `**/*.yml`. Two files weren't aligned with Prettier's output, so on every run `git-auto-commit-action` picked them up and tried to push a diff that included `.github/workflows/update-links.yml` — which GitHub blocks without `workflows` write permission.

Pre-applying the Prettier output here means the format step produces no further changes and the auto-commit only ever touches the actual cache files it's meant to update.

Refs #1020