### PR TITLE
ci: add typecheck step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,5 +45,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Typecheck
+        run: node --run typecheck
+
       - name: Run Tests
         run: node --run test

--- a/e2e-tests/directory.kv.test.ts
+++ b/e2e-tests/directory.kv.test.ts
@@ -11,7 +11,6 @@ import { CACHE_HEADERS } from '../src/constants/cache';
 const mockedEnv: Env = {
   ...env,
   ENVIRONMENT: 'e2e-tests',
-  CACHING: false,
   LOG_ERRORS: true,
   USE_KV: true,
 };

--- a/e2e-tests/directory.s3.test.ts
+++ b/e2e-tests/directory.s3.test.ts
@@ -8,7 +8,6 @@ import { CACHE_HEADERS } from '../src/constants/cache';
 const mockedEnv: Env = {
   ...env,
   ENVIRONMENT: 'e2e-tests',
-  CACHING: false,
   LOG_ERRORS: true,
   S3_ENDPOINT: 'https://s3.mock',
   S3_ACCESS_KEY_ID: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',

--- a/e2e-tests/fallback.test.ts
+++ b/e2e-tests/fallback.test.ts
@@ -8,7 +8,6 @@ import { CACHE_HEADERS } from '../src/constants/cache';
 const mockedEnv: Env = {
   ...env,
   ENVIRONMENT: 'e2e-tests',
-  CACHING: false,
   LOG_ERRORS: false,
   S3_ENDPOINT: 'https://s3.mock',
   S3_ACCESS_KEY_ID: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',

--- a/e2e-tests/file.test.ts
+++ b/e2e-tests/file.test.ts
@@ -8,7 +8,6 @@ import { CACHE_HEADERS } from '../src/constants/cache';
 const mockedEnv: Env = {
   ...env,
   ENVIRONMENT: 'e2e-tests',
-  CACHING: false,
   LOG_ERRORS: true,
 };
 

--- a/e2e-tests/misc.test.ts
+++ b/e2e-tests/misc.test.ts
@@ -7,7 +7,6 @@ import type { Env } from '../src/env';
 const mockedEnv: Env = {
   ...env,
   ENVIRONMENT: 'e2e-tests',
-  CACHING: false,
   LOG_ERRORS: true,
 };
 

--- a/e2e-tests/tsconfig.json
+++ b/e2e-tests/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["@cloudflare/vitest-pool-workers", "../vitest-types.d.ts"]
-  }
+    "types": [
+      "../worker-configuration.d.ts",
+      "@cloudflare/vitest-pool-workers",
+      "../vitest-types.d.ts"
+    ]
+  },
+  "exclude": ["node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "format": "prettier --check --write \"**/*.{ts,js,mjs,json,jsonc,md,yml}\"",
     "prettier": "prettier --check \"**/*.{ts,js,mjs,json,md}\"",
     "lint": "eslint ./src",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p e2e-tests",
     "test": "vitest --run",
     "test:watch": "vitest",
     "build:mustache": "node scripts/compile-mustache.mjs",

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -6,7 +6,7 @@ const byteUnits = ['B', 'KB', 'MB', 'GB', 'TB'];
 export function objectHasBody(
   object: R2Object | R2ObjectBody
 ): object is R2ObjectBody {
-  return (<R2ObjectBody>object).body !== undefined;
+  return (object as R2ObjectBody).body !== undefined;
 }
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8,51 +8,53 @@ import { registerRoutes } from './routes';
 const router: Router = new Router();
 registerRoutes(router);
 
-export default Sentry.withSentry<Env>(
+const handler = {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<Response> {
+    Sentry.setTags({
+      request_id: crypto.randomUUID(),
+      user_agent: request.headers.get('user-agent'),
+      ray_id: request.headers.get('cf-ray'),
+
+      // Type casts needed to keep lsp happy
+      ip_country: request.cf?.country as Iso3166Alpha2Code | undefined,
+      colo: request.cf?.colo as string | undefined,
+    });
+
+    const context: Context = {
+      env: env,
+      execution: ctx,
+    };
+
+    try {
+      const response: unknown = await router.fetch(request, context);
+
+      if (!(response instanceof Response)) {
+        // Didn't get a proper response from the router
+        throw new TypeError(
+          `router response not instanceof Response (typeof=${typeof response}, ctor=${response?.constructor?.name})`
+        );
+      }
+
+      return response;
+    } catch (err) {
+      Sentry.captureException(err);
+
+      if (env.LOG_ERRORS === true) {
+        console.error(err);
+      }
+
+      return responses.internalServerError(err, env);
+    }
+  },
+} satisfies ExportedHandler<Env>;
+
+export default Sentry.withSentry<Env, unknown, unknown, typeof handler>(
   env => ({
     dsn: env.SENTRY_DSN,
   }),
-  {
-    async fetch(
-      request: Request,
-      env: Env,
-      ctx: ExecutionContext
-    ): Promise<Response> {
-      Sentry.setTags({
-        request_id: crypto.randomUUID(),
-        user_agent: request.headers.get('user-agent'),
-        ray_id: request.headers.get('cf-ray'),
-
-        // Type casts needed to keep lsp happy
-        ip_country: request.cf?.country as Iso3166Alpha2Code | undefined,
-        colo: request.cf?.colo as string | undefined,
-      });
-
-      const context: Context = {
-        env: env,
-        execution: ctx,
-      };
-
-      try {
-        const response: unknown = await router.fetch(request, context);
-
-        if (!(response instanceof Response)) {
-          // Didn't get a proper response from the router
-          throw new TypeError(
-            `router response not instanceof Response (typeof=${typeof response}, ctor=${response?.constructor?.name})`
-          );
-        }
-
-        return response;
-      } catch (err) {
-        Sentry.captureException(err);
-
-        if (env.LOG_ERRORS === true) {
-          console.error(err);
-        }
-
-        return responses.internalServerError(err, env);
-      }
-    },
-  } satisfies ExportedHandler<Env>
+  handler
 );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
     "strict": true,
     "skipLibCheck": true,
     "erasableSyntaxOnly": true
-  }
+  },
+  "exclude": ["node_modules", "e2e-tests"]
 }


### PR DESCRIPTION
No CI job ran `tsc`, so type errors could land on `main`. One had: `erasableSyntaxOnly` (#252) retroactively made a pre-existing angle-bracket cast in `src/utils/object.ts` a TS1294 error.

Adds `npm run typecheck` (`tsc --noEmit` over both projects) and wires it into the Tests workflow. Also fixes the errors it surfaced:

- `src/utils/object.ts` — angle-bracket cast to `as`.
- `e2e-tests/tsconfig.json` — its `types` replaced the inherited `worker-configuration.d.ts` instead of extending it, dropping every Workers global.
- `src/worker.ts` — `withSentry<Env>` passed one explicit type arg, so the handler type param fell back to its default `ExportedHandler<Env>` with an optional `fetch`. Passing `typeof handler` fixes the 20 `worker.fetch is possibly undefined` errors without touching the tests.
- Dropped `CACHING: false` from the e2e tests; nothing reads it.